### PR TITLE
Fix for integer overflow in datetime checksum

### DIFF
--- a/database/templates/bigquery.yaml
+++ b/database/templates/bigquery.yaml
@@ -389,7 +389,7 @@ function:
   cast_to_string: cast({field} as string)
   fill_cnt_field: count({field}) as cnt_{field}
   fill_rate_field: round(100.0 * count({field}) / count(*), 2) as prct_{field}
-  checksum_datetime: unix_micros({field})
+  checksum_datetime: cast(unix_micros({field}) as numeric)
   checksum_boolean: 'length(cast({field} as string))'
   checksum_json: "length(replace(nullif(to_json_string({field}), 'null'), ' ', ''))"
 


### PR DESCRIPTION
In Sling we were getting these checksum errors when writing to BigQuery: 

```
DBG googleapi: Error 400: Error in SUM aggregation: integer overflow, invalidQuery
```

I retrieved the SQL from BigQuery history that was causing this error, and narrowed it down to the checksum of datetime fields. If you cast to Numeric type, the error does not occur. 

Note I was not able to actually test this change using Sling, as I'm not familiar with Golang as of yet. 
